### PR TITLE
Gasoline fix

### DIFF
--- a/config/immersivepetroleum.cfg
+++ b/config/immersivepetroleum.cfg
@@ -43,7 +43,7 @@ general {
 
         # Distillation Tower recipes. Format: power_cost, input_name, input_mb -> output1_name, output1_mb, output2_name, output2_mb
         S:towerRecipes <
-            2048, oil, 75 -> lubricant, 9, diesel, 27, gasoline, 39
+            2048, oil, 75 -> lubricant, 9, diesel, 27, fuel, 39
          >
     }
 

--- a/config/immersivepetroleum.cfg
+++ b/config/immersivepetroleum.cfg
@@ -50,7 +50,7 @@ general {
     generation {
         # List of Portable Generator fuels. Format: fluid_name, mb_used_per_tick, flux_produced_per_tick
         S:fuels <
-            gasoline, 5, 256
+            fuel, 5, 256
          >
     }
 
@@ -60,7 +60,7 @@ general {
 
         # List of Motorboat fuels. Format: fluid_name, mb_used_per_tick
         S:boat_fuels <
-            gasoline, 1
+            fuel, 1
          >
     }
 

--- a/scripts/Machines-ImmersiveEngineering.zs
+++ b/scripts/Machines-ImmersiveEngineering.zs
@@ -487,6 +487,14 @@ val  IIngotArray = [<ore:ingotIron>, <ore:ingotGold>, <ore:ingotSilicon>,
     //Make some leather straps
     mods.immersiveengineering.Squeezer.addRecipe(<betterwithmods:material:8> * 2, <liquid:toxic_waste> * 5, <minecraft:rotten_flesh>, 80);
 
+//Mixer
+// Removal
+	//OutputStack
+	//mods.immersiveengineering.Mixer.removeRecipe(<liquid:lava>);
+// Addition
+	//OutputFluid, InputFluid, InputFluid1
+	//mods.immersiveengineering.Mixer.addRecipe(<liquid:lava>, <liquid:water>, [<ore:logWood>, <minecraft:dirt>], 2048);
+	mods.immersiveengineering.Mixer.addRecipe(<liquid:napalm> * 500, <liquid:fuel> * 500, [<ore:dustAluminum>, <ore:dustAluminum>, <ore:dustAluminum>], 3000);
 
    
     

--- a/scripts/Machines-ImmersiveTechnology.zs
+++ b/scripts/Machines-ImmersiveTechnology.zs
@@ -29,5 +29,7 @@
     mods.immersivetechnology.PressurizedFluid.add(<fluid:salt_water>);
 	
 // Gas Turbine
-	mods.immersivetechnology.GasTurbine.addFuel(<liquid:fluegas> * 1000, <liquid:fuel> * 300, 1);
 	mods.immersivetechnology.GasTurbine.removeFuel(<liquid:gasoline>);
+	mods.immersivetechnology.GasTurbine.removeFuel(<liquid:diesel>);
+	mods.immersivetechnology.GasTurbine.addFuel(<liquid:fluegas> * 1000, <liquid:fuel> * 300, 1);
+	mods.immersivetechnology.GasTurbine.addFuel(<liquid:fluegas> * 1000, <liquid:diesel> * 150, 1);

--- a/scripts/Machines-ImmersiveTechnology.zs
+++ b/scripts/Machines-ImmersiveTechnology.zs
@@ -5,7 +5,8 @@
 // Boiler 
     mods.immersivetechnology.Boiler.removeRecipe(<liquid:water>);
     mods.immersivetechnology.Boiler.addRecipe(<liquid:steam> * 500, <liquid:fresh_water> * 250, 10);
-    
+    mods.immersivetechnology.Boiler.addFuel(<liquid:fuel> * 20, 1, 10);
+	mods.immersivetechnology.Boiler.removeFuel(<liquid:gasoline>);
     
 		
 // Distiller
@@ -26,3 +27,7 @@
 // Pipes
     mods.immersivetechnology.PressurizedFluid.add(<fluid:fresh_water>);
     mods.immersivetechnology.PressurizedFluid.add(<fluid:salt_water>);
+	
+// Gas Turbine
+	mods.immersivetechnology.GasTurbine.addFuel(<liquid:fluegas> * 1000, <liquid:fuel> * 300, 1);
+	mods.immersivetechnology.GasTurbine.removeFuel(<liquid:gasoline>);


### PR DESCRIPTION
- Changed destillation tower gasoline output to PnC one
- Removed almost all IP gasoline uses (can't remove the mixer one)
- Added all uses of IP gasoline to PnC gasoline
- Rebalanced the gasoline to be a little bit worse than diesel since you get more of it in the IP destillation tower
- Remove duplicated Diesel use in the Gas Turbine