### PR TITLE
Adjust gas turbine consumption

### DIFF
--- a/scripts/Machines-ImmersiveTechnology.zs
+++ b/scripts/Machines-ImmersiveTechnology.zs
@@ -36,9 +36,9 @@
 	mods.immersivetechnology.GasTurbine.removeFuel(<liquid:gasoline>);
 	mods.immersivetechnology.GasTurbine.removeFuel(<liquid:diesel>);
   mods.immersivetechnology.GasTurbine.removeFuel(<liquid:kerosene>);
-	mods.immersivetechnology.GasTurbine.addFuel(<liquid:flue_gas> * 1000, <liquid:fuel> * 300, 1);
-	mods.immersivetechnology.GasTurbine.addFuel(<liquid:flue_gas> * 1000, <liquid:diesel> * 150, 1);
-  mods.immersivetechnology.GasTurbine.addFuel(<liquid:flue_gas> * 1000, <liquid:kerosene> * 150, 1);
+	mods.immersivetechnology.GasTurbine.addFuel(<liquid:flue_gas> * 1000, <liquid:fuel> * 300, 10);
+	mods.immersivetechnology.GasTurbine.addFuel(<liquid:flue_gas> * 1000, <liquid:diesel> * 150, 10);
+  mods.immersivetechnology.GasTurbine.addFuel(<liquid:flue_gas> * 1000, <liquid:kerosene> * 150, 10);
   
   
 


### PR DESCRIPTION
Changes the gas turbine recipes for  kerosene, diesel, and gasoline to consume every 10 ticks instead of every tick, matching the biodiesel recipe.

related to #120 