### PR TITLE
Airtight Seal available, reverts Chem and Crystal AR machine recipes to defaults

### DIFF
--- a/config/advRocketry/ChemicalReactor.xml
+++ b/config/advRocketry/ChemicalReactor.xml
@@ -31,7 +31,7 @@
 	
 	The "useDefault" attribute will prevent loading of recipes if set to "false"
 <!-->
-<Recipes useDefault="false">
+<Recipes useDefault="true">
 	<Recipe timeRequired="100" power ="10">
 		<input>
 			<fluidStack>oxygen;10</fluidStack>

--- a/config/advRocketry/Crystallizer.xml
+++ b/config/advRocketry/Crystallizer.xml
@@ -31,7 +31,7 @@
 	
 	The "useDefault" attribute will prevent loading of recipes if set to "false"
 <!-->
-<Recipes useDefault="false">
+<Recipes useDefault="true">
 	<Recipe timeRequired="300" power ="20">
 		<input>
 			<oreDict>dustDilithium</oreDict>


### PR DESCRIPTION
There were no changes to these files since they were added to TNFC, so there aren't any customizations to lose.

Tested that all recipes previously available are still present, with the addition of 47 pages of recipes in the Chemical Reactor to add Airtight Seal enchantments to all forms of armor/clothing, including an airtight Nifty Hat!

Note that JEI does not show the enchantment on the output items, even though the recipes do work. This is an issue in vanilla AR. Items enchanted this way may lose all previous enchantments!
