### PR TITLE
made it so now u can craft speed upgrades in stack

### DIFF
--- a/scripts/Crafting-pneumaticcraft.zs
+++ b/scripts/Crafting-pneumaticcraft.zs
@@ -1,10 +1,8 @@
 #priority 3
 #modloaded pneumaticcraft
 
-
-val lubeBucket = <tfc:wooden_bucket>.withTag({Fluid: {FluidName: "lubricant", Amount: 1000}}).giveBack(<tfc:wooden_bucket>);
-val vodkaBottle = <tfc:ceramics/fired/jug>.withTag({Fluid: {FluidName: "vodka", Amount: 100}}).giveBack(<tfc:ceramics/fired/jug>);
-
+val lubeBucket = <liquid:lubricant> * 1000;
+val vodkaBottle = <liquid:vodka> * 100;
 
 //#REMOVE Recipes
   mods.jei.JEI.removeAndHide(<pneumaticcraft:crop_support>);
@@ -57,7 +55,7 @@ val vodkaBottle = <tfc:ceramics/fired/jug>.withTag({Fluid: {FluidName: "vodka", 
       recipes.addShaped("pneumaticcraft_pressure_chamber_glass", <pneumaticcraft:pressure_chamber_glass> * 16, [[<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:blockGlass>, <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
       recipes.addShaped("pneumaticcraft_pressure_chamber_wall", <pneumaticcraft:pressure_chamber_wall> * 16, [[<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:craftingToolHardHammer>.transformDamage(), <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
       recipes.addShaped("pneumaticcraft_pressure_gauge", <pneumaticcraft:pressure_gauge>, [[null, <tfc:metal/ingot/gold>, null], [<tfc:metal/ingot/gold>, <ore:ingotIronCompressed>, <tfc:metal/ingot/gold>], [null, <tfc:metal/ingot/gold>, null]]);
-      recipes.addShaped("pneumaticcraft_speed_upgrade", <pneumaticcraft:speed_upgrade>, [[<ore:gemLapis>, vodkaBottle, <ore:gemLapis>], [vodkaBottle, lubeBucket, vodkaBottle], [<ore:gemLapis>, vodkaBottle, <ore:gemLapis>]]);
+      //recipes.addShaped("pneumaticcraft_speed_upgrade", <pneumaticcraft:speed_upgrade>, [[<ore:gemLapis>, vodkaBottle, <ore:gemLapis>], [vodkaBottle, lubeBucket, vodkaBottle], [<ore:gemLapis>, vodkaBottle, <ore:gemLapis>]]);
       recipes.addShaped("pneumaticcraft_dispenser_upgrade", <pneumaticcraft:dispenser_upgrade>, [[<tfc:ore/lapis_lazuli>, <minecraft:quartz>, <tfc:ore/lapis_lazuli>], [<minecraft:quartz>, <minecraft:dispenser>, <minecraft:quartz>], [<tfc:ore/lapis_lazuli>, <minecraft:quartz>, <tfc:ore/lapis_lazuli>]]);
       recipes.addShaped("pneumaticcraft_uv_light_box", <pneumaticcraft:uv_light_box>, [[<betterwithmods:material:34>, <betterwithmods:material:34>, <betterwithmods:material:34>], [<ore:ingotIronCompressed>, <pneumaticcraft:pcb_blueprint>, <pneumaticcraft:pressure_tube>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
       recipes.addShaped("pneumaticcraft_vortex_tube", <pneumaticcraft:vortex_tube>, [[<ore:ingotIronCompressed>, <pneumaticcraft:pressure_tube>, <ore:ingotIronCompressed>], [<tfc:metal/ingot/gold>, <pneumaticcraft:pressure_tube>, <tfc:metal/ingot/gold>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
@@ -80,6 +78,15 @@ val vodkaBottle = <tfc:ceramics/fired/jug>.withTag({Fluid: {FluidName: "vodka", 
       recipes.addShaped("pneumaticcraft_charging_upgrade", <pneumaticcraft:charging_upgrade>, [[<tfc:ore/lapis_lazuli>, <pneumaticcraft:pressure_tube>, <tfc:ore/lapis_lazuli>], [<pneumaticcraft:pressure_tube>, <pneumaticcraft:charging_module>, <pneumaticcraft:pressure_tube>], [<tfc:ore/lapis_lazuli>, <pneumaticcraft:pressure_tube>, <tfc:ore/lapis_lazuli>]]);
       recipes.addShaped("pneumaticcraft_coordinate_tracker_upgrade", <pneumaticcraft:coordinate_tracker_upgrade>, [[<tfc:ore/lapis_lazuli>, <minecraft:redstone>, <tfc:ore/lapis_lazuli>], [<minecraft:redstone>, <pneumaticcraft:gps_tool>, <minecraft:redstone>], [<tfc:ore/lapis_lazuli>, <minecraft:redstone>, <tfc:ore/lapis_lazuli>]]);
       recipes.addShaped("pneumaticcraft_entity_tracker_upgrade", <pneumaticcraft:entity_tracker_upgrade>, [[<tfc:ore/lapis_lazuli>, <minecraft:bone>, <tfc:ore/lapis_lazuli>], [<minecraft:bone>, <advancedrocketry:productgear>, <minecraft:bone>], [<tfc:ore/lapis_lazuli>, <minecraft:bone>, <tfc:ore/lapis_lazuli>]]);
+      
+      recipes.addShaped("pneumaticcraft_speed_upgrade", <pneumaticcraft:speed_upgrade>, [[<ore:gemLapis>, vodka, <ore:gemLapis>], [vodka, lube, vodka], [<ore:gemLapis>, vodka, <ore:gemLapis>]],
+	    function(out, ins, cInfo)
+	    {
+		    if(cInfo.inventory.itemArray has <tfc:wooden_bucket>.withTag({Fluid: {FluidName: "vodka", Amount: 1000}}) || cInfo.inventory.itemArray has <forge:bucketfilled>.withTag({FluidName: "vodka", Amount: 1000})) return null;
+		    return out;
+	    },
+	    null);
+	  
       
       // ================================================================================
 //#ADD SHAPELESS


### PR DESCRIPTION
1. Change names of vodkaBottle and lubeBucket to vodka and lube as well as their values to be of IliquidStack this makes the recipes more flexible when it comes to fluids.
2. Commentted out the old recipe and added a new with a function which prohibits crafting with a bucket of vodka - since the recipe uses only 100 mb of this liquid and buckets can hold either 1000 mb or 0 mb, it worked kinda wonky