### PR TITLE
Oil and PNC fixes for previous PRs

### DIFF
--- a/Curse/overrides/scripts/Crafting-pneumaticcraft.zs
+++ b/Curse/overrides/scripts/Crafting-pneumaticcraft.zs
@@ -1,10 +1,8 @@
 #priority 3
 #modloaded pneumaticcraft
 
-
-val lubeBucket = <tfc:wooden_bucket>.withTag({Fluid: {FluidName: "lubricant", Amount: 1000}}).giveBack(<tfc:wooden_bucket>);
-val vodkaBottle = <tfc:ceramics/fired/jug>.withTag({Fluid: {FluidName: "vodka", Amount: 100}}).giveBack(<tfc:ceramics/fired/jug>);
-
+val lube = <liquid:lubricant> * 1000;
+val vodka = <liquid:vodka> * 100;
 
 //#REMOVE Recipes
   mods.jei.JEI.removeAndHide(<pneumaticcraft:crop_support>);
@@ -57,7 +55,7 @@ val vodkaBottle = <tfc:ceramics/fired/jug>.withTag({Fluid: {FluidName: "vodka", 
       recipes.addShaped("pneumaticcraft_pressure_chamber_glass", <pneumaticcraft:pressure_chamber_glass> * 16, [[<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:blockGlass>, <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
       recipes.addShaped("pneumaticcraft_pressure_chamber_wall", <pneumaticcraft:pressure_chamber_wall> * 16, [[<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:craftingToolHardHammer>.transformDamage(), <ore:ingotIronCompressed>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
       recipes.addShaped("pneumaticcraft_pressure_gauge", <pneumaticcraft:pressure_gauge>, [[null, <tfc:metal/ingot/gold>, null], [<tfc:metal/ingot/gold>, <ore:ingotIronCompressed>, <tfc:metal/ingot/gold>], [null, <tfc:metal/ingot/gold>, null]]);
-      recipes.addShaped("pneumaticcraft_speed_upgrade", <pneumaticcraft:speed_upgrade>, [[<ore:gemLapis>, vodkaBottle, <ore:gemLapis>], [vodkaBottle, lubeBucket, vodkaBottle], [<ore:gemLapis>, vodkaBottle, <ore:gemLapis>]]);
+      //recipes.addShaped("pneumaticcraft_speed_upgrade", <pneumaticcraft:speed_upgrade>, [[<ore:gemLapis>, vodkaBottle, <ore:gemLapis>], [vodkaBottle, lubeBucket, vodkaBottle], [<ore:gemLapis>, vodkaBottle, <ore:gemLapis>]]);
       recipes.addShaped("pneumaticcraft_dispenser_upgrade", <pneumaticcraft:dispenser_upgrade>, [[<tfc:ore/lapis_lazuli>, <minecraft:quartz>, <tfc:ore/lapis_lazuli>], [<minecraft:quartz>, <minecraft:dispenser>, <minecraft:quartz>], [<tfc:ore/lapis_lazuli>, <minecraft:quartz>, <tfc:ore/lapis_lazuli>]]);
       recipes.addShaped("pneumaticcraft_uv_light_box", <pneumaticcraft:uv_light_box>, [[<betterwithmods:material:34>, <betterwithmods:material:34>, <betterwithmods:material:34>], [<ore:ingotIronCompressed>, <pneumaticcraft:pcb_blueprint>, <pneumaticcraft:pressure_tube>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
       recipes.addShaped("pneumaticcraft_vortex_tube", <pneumaticcraft:vortex_tube>, [[<ore:ingotIronCompressed>, <pneumaticcraft:pressure_tube>, <ore:ingotIronCompressed>], [<tfc:metal/ingot/gold>, <pneumaticcraft:pressure_tube>, <tfc:metal/ingot/gold>], [<ore:ingotIronCompressed>, <ore:ingotIronCompressed>, <ore:ingotIronCompressed>]]);
@@ -80,6 +78,15 @@ val vodkaBottle = <tfc:ceramics/fired/jug>.withTag({Fluid: {FluidName: "vodka", 
       recipes.addShaped("pneumaticcraft_charging_upgrade", <pneumaticcraft:charging_upgrade>, [[<tfc:ore/lapis_lazuli>, <pneumaticcraft:pressure_tube>, <tfc:ore/lapis_lazuli>], [<pneumaticcraft:pressure_tube>, <pneumaticcraft:charging_module>, <pneumaticcraft:pressure_tube>], [<tfc:ore/lapis_lazuli>, <pneumaticcraft:pressure_tube>, <tfc:ore/lapis_lazuli>]]);
       recipes.addShaped("pneumaticcraft_coordinate_tracker_upgrade", <pneumaticcraft:coordinate_tracker_upgrade>, [[<tfc:ore/lapis_lazuli>, <minecraft:redstone>, <tfc:ore/lapis_lazuli>], [<minecraft:redstone>, <pneumaticcraft:gps_tool>, <minecraft:redstone>], [<tfc:ore/lapis_lazuli>, <minecraft:redstone>, <tfc:ore/lapis_lazuli>]]);
       recipes.addShaped("pneumaticcraft_entity_tracker_upgrade", <pneumaticcraft:entity_tracker_upgrade>, [[<tfc:ore/lapis_lazuli>, <minecraft:bone>, <tfc:ore/lapis_lazuli>], [<minecraft:bone>, <advancedrocketry:productgear>, <minecraft:bone>], [<tfc:ore/lapis_lazuli>, <minecraft:bone>, <tfc:ore/lapis_lazuli>]]);
+      
+      recipes.addShaped("pneumaticcraft_speed_upgrade", <pneumaticcraft:speed_upgrade>, [[<ore:gemLapis>, vodka, <ore:gemLapis>], [vodka, lube, vodka], [<ore:gemLapis>, vodka, <ore:gemLapis>]],
+	    function(out, ins, cInfo)
+	    {
+		    if(cInfo.inventory.itemArray has <tfc:wooden_bucket>.withTag({Fluid: {FluidName: "vodka", Amount: 1000}}) || cInfo.inventory.itemArray has <forge:bucketfilled>.withTag({FluidName: "vodka", Amount: 1000})) return null;
+		    return out;
+	    },
+	    null);
+	  
       
       // ================================================================================
 //#ADD SHAPELESS

--- a/Curse/overrides/scripts/Machines-Horsepower.zs
+++ b/Curse/overrides/scripts/Machines-Horsepower.zs
@@ -184,7 +184,7 @@
  
 // Press
   mods.horsepower.Press.add(<tfc:food/olive_paste>, <liquid:olive_oil_water> * 250);
-  mods.horsepower.Press.add(<tfc:crop/product/olive_jute_disc>, <tfc:crop/product/jute_disc>, <liquid:olive_oil> * 96);
+  mods.horsepower.Press.add(<tfc:crop/product/olive_jute_disc>, <tfc:crop/product/jute_disc>, <liquid:olive_oil> * 100);
   mods.horsepower.Press.add(<ore:logWoodTannin>, <liquid:creosote> * 125);
   
   //Cloth

--- a/Curse/overrides/scripts/Machines-ImmersiveEngineering.zs
+++ b/Curse/overrides/scripts/Machines-ImmersiveEngineering.zs
@@ -42,6 +42,26 @@ val  IIngotArray = [<ore:ingotIron>, <ore:ingotGold>, <ore:ingotSilicon>,
     mods.immersiveengineering.MetalPress.removeRecipe(<libvulpes:productplate:7>);
     mods.immersiveengineering.MetalPress.removeRecipe(<libvulpes:productplate:9>);
     
+    // Clay mold recipes
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/jug>, <minecraft:clay_ball>, <tfc:ceramics/fired/jug>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/vessel>, <minecraft:clay_ball>, <tfc:ceramics/fired/vessel>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/clay_flower_pot> * 2, <minecraft:clay_ball>, <minecraft:flower_pot>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/pot>, <minecraft:clay_ball>, <tfc:ceramics/fired/pot>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/clay_brick> * 3, <minecraft:clay_ball>, <minecraft:brick>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<firmalife:unfired_mallet_mold>, <minecraft:clay_ball>, <firmalife:steel_mallet_head>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfctech:ceramics/unfired/sleeve>, <minecraft:clay_ball>, <tfctech:metal/steel_sleeve>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfctech:ceramics/unfired/rackwheel_piece>, <minecraft:clay_ball>, <tfctech:metal/steel_rackwheel_piece>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfctech:ceramics/unfired/glass_block>, <minecraft:clay_ball>, <minecraft:glass>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfctech:ceramics/unfired/glass_pane>, <minecraft:clay_ball>, <minecraft:glass_pane>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfcthings:mold/unfired/prospectors_hammer_head>, <minecraft:clay_ball>, <tfcthings:prospectors_hammer_head/steel>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/bowl>*3, <minecraft:clay_ball>, <tfc:ceramics/fired/bowl>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/large_vessel>, <minecraft:clay_ball>, <tfc:ceramics/fired/large_vessel>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/crucible>, <tfc:ceramics/fire_clay>, <tfc:crucible>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<tfc:ceramics/unfired/fire_brick>*3, <tfc:ceramics/fire_clay>, <tfc:ceramics/fired/fire_brick>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<firmalife:oven>, <minecraft:clay_ball>, <firmalife:oven>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<firmalife:oven_wall>, <minecraft:clay_ball>, <firmalife:oven_wall>, 2400, 5);
+    mods.immersiveengineering.MetalPress.addRecipe(<firmalife:oven_chimney>, <minecraft:clay_ball>, <firmalife:oven_chimney>, 2400, 5);
+
     
     //Copied from 1.7.10 - Uses Steel block as mold because meh....it worked then too
     mods.immersiveengineering.MetalPress.addRecipe(<tfc:metal/ingot/high_carbon_steel>, <tfc:metal/ingot/pig_iron>, <immersiveengineering:storage:8>, 2400, 1);
@@ -595,9 +615,8 @@ val  IIngotArray = [<ore:ingotIron>, <ore:ingotGold>, <ore:ingotSilicon>,
     //Make some leather straps
     mods.immersiveengineering.Squeezer.addRecipe(<betterwithmods:material:8> * 2, <liquid:toxic_waste> * 5, <minecraft:rotten_flesh>, 80);
 
-
-    mods.immersiveengineering.Squeezer.addRecipe(null, <liquid:olive_oil> * 48, <tfc:food/olive_paste>, 80);
-    mods.immersiveengineering.Squeezer.addRecipe(<tfc:crop/product/jute_disc>,  <liquid:olive_oil> * 144, <tfc:crop/product/olive_jute_disc>, 80);
+    mods.immersiveengineering.Squeezer.addRecipe(null, <liquid:olive_oil> * 50, <tfc:food/olive_paste>, 80);
+    mods.immersiveengineering.Squeezer.addRecipe(<tfc:crop/product/jute_disc>,  <liquid:olive_oil> * 150, <tfc:crop/product/olive_jute_disc>, 80);
 //Mixer
 // Removal
 	//OutputStack
@@ -626,4 +645,5 @@ mods.immersiveengineering.AlloySmelter.addRecipe(<tfc:metal/ingot/brass> * 9, <o
 //Refinery
 //mods.immersiveengineering.Refinery.addRecipe(ILiquidStack output, ILiquidStack input0, ILiquidStack input1, int energy);
 
-mods.immersiveengineering.Refinery.addRecipe(<liquid:biodiesel>*16, <liquid:olive_oil>*8, <liquid:ethanol>*8, 80);
+// olive oil is created in multiples of 10mb, not 8mb, so olive oil is just a little less efficient than hempseed oil to avoid oil chads
+mods.immersiveengineering.Refinery.addRecipe(<liquid:biodiesel>*16, <liquid:olive_oil>*10, <liquid:ethanol>*8, 80);

--- a/scripts/Crafting-pneumaticcraft.zs
+++ b/scripts/Crafting-pneumaticcraft.zs
@@ -1,8 +1,8 @@
 #priority 3
 #modloaded pneumaticcraft
 
-val lubeBucket = <liquid:lubricant> * 1000;
-val vodkaBottle = <liquid:vodka> * 100;
+val lube = <liquid:lubricant> * 1000;
+val vodka = <liquid:vodka> * 100;
 
 //#REMOVE Recipes
   mods.jei.JEI.removeAndHide(<pneumaticcraft:crop_support>);

--- a/scripts/Machines-ImmersiveEngineering.zs
+++ b/scripts/Machines-ImmersiveEngineering.zs
@@ -61,7 +61,7 @@ val  IIngotArray = [<ore:ingotIron>, <ore:ingotGold>, <ore:ingotSilicon>,
     mods.immersiveengineering.MetalPress.addRecipe(<firmalife:oven>, <minecraft:clay_ball>, <firmalife:oven>, 2400, 5);
     mods.immersiveengineering.MetalPress.addRecipe(<firmalife:oven_wall>, <minecraft:clay_ball>, <firmalife:oven_wall>, 2400, 5);
     mods.immersiveengineering.MetalPress.addRecipe(<firmalife:oven_chimney>, <minecraft:clay_ball>, <firmalife:oven_chimney>, 2400, 5);
-    
+
     
     //Copied from 1.7.10 - Uses Steel block as mold because meh....it worked then too
     mods.immersiveengineering.MetalPress.addRecipe(<tfc:metal/ingot/high_carbon_steel>, <tfc:metal/ingot/pig_iron>, <immersiveengineering:storage:8>, 2400, 1);
@@ -645,4 +645,5 @@ mods.immersiveengineering.AlloySmelter.addRecipe(<tfc:metal/ingot/brass> * 9, <o
 //Refinery
 //mods.immersiveengineering.Refinery.addRecipe(ILiquidStack output, ILiquidStack input0, ILiquidStack input1, int energy);
 
-mods.immersiveengineering.Refinery.addRecipe(<liquid:biodiesel>*16, <liquid:olive_oil>*8, <liquid:ethanol>*8, 80);
+// olive oil is created in multiples of 10mb, not 8mb, so olive oil is just a little less efficient than hempseed oil to avoid oil chads
+mods.immersiveengineering.Refinery.addRecipe(<liquid:biodiesel>*16, <liquid:olive_oil>*10, <liquid:ethanol>*8, 80);

--- a/scripts/TFC - Mechanics Recipes.zs
+++ b/scripts/TFC - Mechanics Recipes.zs
@@ -56,7 +56,7 @@ for i, item in IIngotArray {
 //mods.terrafirmacraft.Barrel.removeRecipe(<tfc:crop/product/dirty_jute_net>, <liquid:olive_oil>);
 mods.terrafirmacraft.Barrel.removeRecipe("tfc:olive_oil");
 
-mods.terrafirmacraft.Barrel.addRecipe("tnfc:50_olive_oil", <tfc:crop/product/jute_net>, <liquid:olive_oil_water> * 250, <tfc:crop/product/dirty_jute_net>, <liquid:olive_oil> * 48, 0);
+mods.terrafirmacraft.Barrel.addRecipe("tnfc:50_olive_oil", <tfc:crop/product/jute_net>, <liquid:olive_oil_water> * 250, <tfc:crop/product/dirty_jute_net>, <liquid:olive_oil> * 50, 0);
 
 mods.terrafirmacraft.Barrel.addRecipe("tnfc:treated_wood", <ore:plankWood> * 8, <liquid:creosote> * 1000, <immersiveengineering:treated_wood> * 8, null, 1);
 mods.terrafirmacraft.Barrel.addRecipe("tnfc:tallow", <ore:categoryMeat> * 4, <liquid:hot_water> * 250, <betterwithmods:material:13> * 4, null, 8);


### PR DESCRIPTION
Oil yields are adjusted back so the player may be able to pull out all of the oil from a barrel with a bucket, and all yields are multiples of 50.

Changes Olive oil refinery recipe from @Shadefang  to consume units of 10mb of olive oil instead of 8mb so player gets an empty refinery at the end. Removes changes in #159. 

The Curse/overrides/scripts directory is updated to match scripts/.

Makes the variable names agree with changed recipes in #158, and speed upgrades are indeed craftable with barrels and tanks of fluids! They're pretty laggy though, maybe it's that function?

